### PR TITLE
Implement test-only include directories

### DIFF
--- a/cvra_packager/CMakeLists.txt.jinja
+++ b/cvra_packager/CMakeLists.txt.jinja
@@ -21,6 +21,9 @@ add_executable(
     {% endfor -%}
     )
 
+{% for dir in include_directories.test -%}
+target_include_directories(tests PRIVATE {{ dir }})
+{%- endfor %}
 
 target_link_libraries(
     tests

--- a/cvra_packager/packager.py
+++ b/cvra_packager/packager.py
@@ -153,6 +153,11 @@ def generate_source_list(package, category, filemap=None):
 
     return sorted(source_list)
 
+# Just needed to have a Python implementation of list because lists are not
+# dynamic enough in CPython
+class ListWrapper(list):
+    pass
+
 def generate_source_dict(package, filemap=None):
     """
     Generates a dictionary containing a list of files for each source category.
@@ -161,10 +166,14 @@ def generate_source_dict(package, filemap=None):
     result = dict()
 
     for cat in ["source", "tests", "include_directories"]:
-        result[cat] = generate_source_list(package, category=cat, filemap=filemap)
+        result[cat] = ListWrapper(generate_source_list(package, category=cat, filemap=filemap))
 
-    result["target"] = dict()
+    # Append test directories
+    test_inc = generate_source_list(package, category="include_directories.test",
+                                    filemap=filemap)
+    setattr(result["include_directories"], "test", test_inc)
 
+    result['target'] = dict()
     targets = [key for key in package.keys() if key.startswith("target.")]
 
     for tar in targets:

--- a/tests/tests_source_list.py
+++ b/tests/tests_source_list.py
@@ -130,4 +130,16 @@ class GenerateSourceListTestCase(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
+    @patch('cvra_packager.packager.open_package')
+    def test_include_directory_for_tests(self, open_package_mock):
+        """
+        Tests that the include directories for tests are included as well.
+        """
+        package = {'sources':['application.c'],'depends':['pid']}
+        pid_package = {'sources':['pid.c'], 'include_directories.test':['poney']}
+        open_package_mock.return_value = pid_package
 
+        result = generate_source_dict(package)
+        expected = [os.path.join(DEPENDENCIES_DIR, 'pid', 'poney')]
+
+        self.assertEqual(result['include_directories'].test, expected)


### PR DESCRIPTION
This allows the user to specify includes that will be used only for tests, e.g., to override platform specific includes.

I want to use it to create a mock package for ChibiOS, instead of half implementing it every time.