### PR TITLE
Fix unit tests on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
     - "3.4"
     - "3.5"
+    - "3.6"
 
 install:
     - python setup.py install

--- a/cvra_packager/packager.py
+++ b/cvra_packager/packager.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 
 
 BUILD_DIR = "build/"
-DEPENDENCIES_DIR = "dependencies/"
+DEPENDENCIES_DIR = "dependencies"
 
 def url_for_package(package):
     """

--- a/tests/tests_dependency_download.py
+++ b/tests/tests_dependency_download.py
@@ -1,6 +1,8 @@
 import unittest
 from cvra_packager.packager import *
 
+from os.path import join
+
 try:
     from unittest.mock import *
 except ImportError:
@@ -91,7 +93,7 @@ class DependencyTestCase(unittest.TestCase):
 
         download_dependencies(package, method=self.clone, filemap=filemap)
 
-        self.clone.assert_any_call('https://github.com/cvra/pid', 'foo/pid')
+        self.clone.assert_any_call('https://github.com/cvra/pid', join('foo', 'pid'))
         self.clone.assert_any_call('https://github.com/cvra/test-runner', 'foo/test-runner')
 
     @patch('os.path.exists')
@@ -142,7 +144,7 @@ class DependencyTestCase(unittest.TestCase):
 
         download_dependencies(package, method=self.clone, filemap=m)
 
-        self.clone.assert_any_call('https://github.com/cvra/pid', 'foo/pid')
+        self.clone.assert_any_call('https://github.com/cvra/pid', join('foo', 'pid'))
 
 
 

--- a/tests/tests_integration.py
+++ b/tests/tests_integration.py
@@ -38,6 +38,7 @@ class IntegrationTesting(unittest.TestCase):
         from cvra_packager.packager import main as packager_main
 
         pkgfile_content = '''
+        dependency-dir: src
         templates:
             Makefile.jinja: Makefile
             Test.jinja: Test
@@ -49,7 +50,7 @@ class IntegrationTesting(unittest.TestCase):
         empty_context = {'source': [],
                          'target': {},
                          'tests': [],
-                         'include_directories': ['dependencies']
+                         'include_directories': ['src']
                          }
 
         render_mock.assert_any_call('Makefile.jinja', 'Makefile', empty_context)

--- a/tests/tests_integration.py
+++ b/tests/tests_integration.py
@@ -1,5 +1,6 @@
 import unittest
 from cvra_packager.packager import *
+from os.path import join
 
 try:
     from unittest.mock import *
@@ -48,7 +49,7 @@ class IntegrationTesting(unittest.TestCase):
         empty_context = {'source': [],
                          'target': {},
                          'tests': [],
-                         'include_directories': ['dependencies/']
+                         'include_directories': ['dependencies']
                          }
 
         render_mock.assert_any_call('Makefile.jinja', 'Makefile', empty_context)
@@ -72,8 +73,8 @@ class IntegrationTesting(unittest.TestCase):
 
         expected_context = {'source': [],
                             'target': {},
-                            'tests': ['./pid_test.cpp'],
-                            'include_directories': ['dependencies/']
+                            'tests': [join('.','pid_test.cpp')],
+                            'include_directories': ['dependencies']
                             }
         render_mock.assert_any_call('CMakeLists.txt.jinja', 'CMakeLists.txt', expected_context)
 

--- a/tests/tests_misc.py
+++ b/tests/tests_misc.py
@@ -1,5 +1,6 @@
 import unittest
 from cvra_packager.packager import *
+from os.path import join
 
 try:
     from unittest.mock import *
@@ -22,7 +23,7 @@ class OpenPackageTestCase(unittest.TestCase):
         """
         with patch('cvra_packager.packager.open', mock_open(read_data=self.package_content), create=True) as m:
             package = open_package('pid')
-            m.assert_called_with('dependencies/pid/package.yml')
+            m.assert_called_with(join('dependencies', 'pid', 'package.yml'))
 
         self.assertEqual(self.expected, package)
 
@@ -34,7 +35,7 @@ class OpenPackageTestCase(unittest.TestCase):
 
         with patch('cvra_packager.packager.open', mock_open(read_data=self.package_content), create=True) as m:
             package = open_package('pid', {'pid':'foo'})
-            m.assert_called_with('foo/pid/package.yml')
+            m.assert_called_with(join('foo', 'pid', 'package.yml'))
 
         expected = {"source":['pid.c', 'pidconfig.c']}
         self.assertEqual(self.expected, package)

--- a/tests/tests_package_path.py
+++ b/tests/tests_package_path.py
@@ -1,5 +1,6 @@
 import unittest
 from cvra_packager.packager import *
+from os.path import join
 
 class PackageNameTest(unittest.TestCase):
     def test_pkgname_trivial_case(self):
@@ -14,9 +15,11 @@ class PackageNameTest(unittest.TestCase):
         self.assertEqual("pid", package_name_from_desc(package))
 
     def test_pkgfile_trivial_case(self):
-        """ Checks that we can correctly generate the package file path. """
+        """
+        Checks that we can correctly generate the package file path.
+        """
         package = "pid"
-        expected = "dependencies/pid/package.yml"
+        expected = join('dependencies', 'pid', 'package.yml')
         self.assertEqual(expected, pkgfile_for_package(package))
 
     def test_pkgfile_complex_case(self):
@@ -24,7 +27,7 @@ class PackageNameTest(unittest.TestCase):
         Checks that we can correctly find the package.yml file for complex packages.
         """
         package = {"pid":{"fork":"antoinealb"}}
-        expected = "dependencies/pid/package.yml"
+        expected = join('dependencies', 'pid', 'package.yml')
         self.assertEqual(expected, pkgfile_for_package(package))
 
     def test_path_for_package_simple_case(self):
@@ -32,7 +35,7 @@ class PackageNameTest(unittest.TestCase):
         Checks that we can find the path to a package directory (trivial case).
         """
         package = "pid"
-        expected = "dependencies/pid"
+        expected = join('dependencies', 'pid')
         self.assertEqual(expected, path_for_package(package))
 
     def test_path_for_package_complex_case(self):
@@ -46,6 +49,6 @@ class PackageNameTest(unittest.TestCase):
         """
         package = "pid"
         m = {"pid":"control"}
-        self.assertEqual("control/pid", path_for_package(package, m))
+        self.assertEqual(join('control', 'pid'), path_for_package(package, m))
 
 

--- a/tests/tests_source_list.py
+++ b/tests/tests_source_list.py
@@ -1,5 +1,7 @@
 import unittest
 from cvra_packager.packager import *
+from os.path import join
+
 try:
     from unittest.mock import *
 except ImportError:
@@ -37,7 +39,7 @@ class GenerateSourceListTestCase(unittest.TestCase):
 
         result = generate_source_list(package, 'sources', filemap=filemap)
 
-        self.assertEqual(['./application.c', 'foo/pid/pid.c'], result)
+        self.assertEqual(['./application.c', join('foo', 'pid', 'pid.c')], result)
 
         # Checks that the opened file is foo/pid/package.yml
         open_package_mock.assert_called_with('pid', filemap)
@@ -53,7 +55,7 @@ class GenerateSourceListTestCase(unittest.TestCase):
         open_package_mock.return_value = pid_package
 
         result = generate_source_list(package, 'sources')
-        expected = ['./application.c', 'dependencies/pid/pid.c']
+        expected = ['./application.c', join('dependencies', 'pid', 'pid.c')]
 
         self.assertEqual(sorted(expected), sorted(result))
 


### PR DESCRIPTION
On Windows path uses backslashes. This commit replaces the hardcoded
forward slashes (which only work on Unix) by Python's os.path.join which
does the right thing depending on the platform and is already used in
the code itself.

Fixes #17 
