### PR TITLE
Use c++14 in CMake build by default

### DIFF
--- a/cvra_packager/CMakeLists.txt.jinja
+++ b/cvra_packager/CMakeLists.txt.jinja
@@ -7,7 +7,8 @@ set(CMAKE_BUILD_TYPE Debug)
 include_directories({{ dir }})
 {% endfor %}
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -Wall")
+SET(CMAKE_CXX_STANDARD 14)
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 
 add_executable(

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if sys.version_info.major != 3 or sys.version_info.minor < 4:
 
 setup(
     name='cvra-packager',
-    version='1.1.3',
+    version='1.2.0',
     description='CVRA packaging system',
     author='Club Vaudois de Robotique Autonome',
     author_email='info@cvra.ch',


### PR DESCRIPTION
I think we can safely use that, everyone has a decent compiler nowadays, do we ?

I will update it on Pypi once it gets merged.