### PR TITLE
Fix PyYAML API calls

### DIFF
--- a/cvra_packager/packager.py
+++ b/cvra_packager/packager.py
@@ -94,7 +94,7 @@ def open_package(package, filemap=None):
     Load a package given its description / name.
     """
     pkgfile = pkgfile_for_package(package, filemap)
-    return yaml.load(open(pkgfile).read())
+    return yaml.load(open(pkgfile).read(), Loader=yaml.SafeLoader)
 
 def download_dependencies(package, method, filemap=None):
     """
@@ -248,7 +248,7 @@ def main():
     args = parse_args()
 
     try:
-        package = yaml.load(open("package.yml").read())
+        package = yaml.load(open("package.yml").read(), Loader=yaml.SafeLoader)
     except FileNotFoundError:
         print('package.yml was not found. Did you forget to git add it ?')
         return

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ setup(
         'Programming Language :: Python :: 3.6',
         ],
     install_requires=[
-        'pyyaml',
-        'jinja2',
+        'pyyaml~=5.1.2',
+        'jinja2~=2.10.1',
         ],
     package_data = {
         '': ['*.jinja'],


### PR DESCRIPTION
See [0] for explanation of why loading YaML directly is not allowed
anymore.

[0] https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation