### PR TITLE
Allow disabling generation of unittest CMakeLists

### DIFF
--- a/cvra_packager/packager.py
+++ b/cvra_packager/packager.py
@@ -266,7 +266,9 @@ def main():
 
     context['include_directories'].append(dep)
 
-    if context["tests"]:
+    render_cmakelists_for_tests = package.get("render_cmakelists_for_tests", True)
+
+    if context["tests"] and render_cmakelists_for_tests:
         render_template_to_file("CMakeLists.txt.jinja", "CMakeLists.txt", context)
 
     if "templates" in package:

--- a/tests/tests_integration.py
+++ b/tests/tests_integration.py
@@ -79,6 +79,29 @@ class IntegrationTesting(unittest.TestCase):
                             }
         render_mock.assert_any_call('CMakeLists.txt.jinja', 'CMakeLists.txt', expected_context)
 
+    @patch('cvra_packager.packager.render_template_to_file')
+    def test_unit_tests_cmake_can_be_disabled(self, render_mock):
+        """
+        Tests that some top level package.yml can disable rendering of
+        CMakeLists.txt. This is useful as we slowly migrate boards to
+        CMake-based builds and we do not want to overwrite manually-written
+        CMakeLists.txt.
+        """
+        from cvra_packager.packager import main as packager_main
+
+        pkgfile_content = '''
+        tests:
+            - pid_test.cpp
+
+        render_cmakelists_for_tests: False
+        '''
+
+        with patch('cvra_packager.packager.open', mock_open(read_data=pkgfile_content), create=True):
+            packager_main()
+
+        render_mock.assert_not_called()
+
+
     def test_can_find_template(self):
         """
         Checks that we can find template using create_jinja_env.


### PR DESCRIPTION
Some boards now have a manually written CMakeLists.txt as we try to
migrate away from package.yml-based builds. This means that in those
cases, running packager overwrites a manually written file, possibly
erasing uncommitted changes.

To avoid this, we add a setting in the package.yml that can be used to
disable the default behavior of generating the CMakeLists.txt if the
project contains any unit tests (which probably was a bad feature to
begin with).